### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10


### PR DESCRIPTION
A ferramenta dependabot é fornecida pelo próprio GitHub. Ela checa por atualizações nas dependências dos projetos e gera automaticamente o pull request de atualização da versão. É bom para sempre utilizarmos uma versão ativa dos projetos que dependemos.
